### PR TITLE
GT-988 update gulp sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/solarmosaic/gulp-task-sass",
   "dependencies": {
-    "gulp-sass": "^1.3.3",
+    "gulp-sass": "^2.2.0",
     "gulp-sourcemaps": "^1.5.0",
     "lodash.assign": "^3.0.0",
     "stream-combiner": "^0.2.1"


### PR DESCRIPTION
previous versions of lib-sass did not support sass default! variable overrides. 